### PR TITLE
test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,32 +15,32 @@ jobs:
     strategy:
       matrix:
         env: [
-          { os: macos-14,     cxx: /usr/bin/clang++,    c: /usr/bin/clang,    arch: x64, gen: Ninja,                 cxx_max: 23 },
-          { os: macos-15,     cxx: /usr/bin/clang++,    c: /usr/bin/clang,    arch: x64, gen: Ninja,                 cxx_max: 23 },
-          { os: macos-26,     cxx: /usr/bin/clang++,    c: /usr/bin/clang,    arch: x64, gen: Ninja,                 cxx_max: 23 },
-          
-          { os: ubuntu-22.04, cxx: g++-10,     c: gcc-10,   arch: x64, gen: Ninja,                 cxx_max: 17 },
-          { os: ubuntu-22.04, cxx: g++-11,     c: gcc-11,   arch: x64, gen: Ninja,                 cxx_max: 23 },
-          { os: ubuntu-22.04, cxx: clang++-13, c: clang-13, arch: x64, gen: Ninja,                 cxx_max: 20 },
-          { os: ubuntu-22.04, cxx: clang++-14, c: clang-14, arch: x64, gen: Ninja,                 cxx_max: 20 },
-          { os: ubuntu-22.04, cxx: clang++-15, c: clang-15, arch: x64, gen: Ninja,                 cxx_max: 20 },
+          { os: macos-14,            cxx: /usr/bin/clang++, c: /usr/bin/clang, arch: x64, gen: Ninja,                 cxx_max: 23 },
+          { os: macos-15,            cxx: /usr/bin/clang++, c: /usr/bin/clang, arch: x64, gen: Ninja,                 cxx_max: 23 },
+          { os: macos-26,            cxx: /usr/bin/clang++, c: /usr/bin/clang, arch: x64, gen: Ninja,                 cxx_max: 23 },
 
-          { os: ubuntu-24.04, cxx: g++-12,     c: gcc-12,   arch: x64, gen: Ninja,                 cxx_max: 23 },
-          { os: ubuntu-24.04, cxx: g++-13,     c: gcc-13,   arch: x64, gen: Ninja,                 cxx_max: 23 },
-          { os: ubuntu-24.04, cxx: g++-14,     c: gcc-14,   arch: x64, gen: Ninja,                 cxx_max: 23 },
-          { os: ubuntu-24.04, cxx: clang++-16, c: clang-16, arch: x64, gen: Ninja,                 cxx_max: 20 },
-          { os: ubuntu-24.04, cxx: clang++-17, c: clang-17, arch: x64, gen: Ninja,                 cxx_max: 20 },
-          { os: ubuntu-24.04, cxx: clang++-18, c: clang-18, arch: x64, gen: Ninja,                 cxx_max: 23 },
+          { os: ubuntu-22.04,        cxx: g++-10,           c: gcc-10,         arch: x64, gen: Ninja,                 cxx_max: 17 },
+          { os: ubuntu-22.04,        cxx: g++-11,           c: gcc-11,         arch: x64, gen: Ninja,                 cxx_max: 23 },
+          { os: ubuntu-22.04,        cxx: clang++-13,       c: clang-13,       arch: x64, gen: Ninja,                 cxx_max: 20 },
+          { os: ubuntu-22.04,        cxx: clang++-14,       c: clang-14,       arch: x64, gen: Ninja,                 cxx_max: 20 },
+          { os: ubuntu-22.04,        cxx: clang++-15,       c: clang-15,       arch: x64, gen: Ninja,                 cxx_max: 20 },
 
-          { os: windows-2022, cxx: cl,         c: cl,       arch: x86, gen: Visual Studio 17 2022, cxx_max: 23 },
-          { os: windows-2022, cxx: cl,         c: cl,       arch: x64, gen: Visual Studio 17 2022, cxx_max: 23 },
-          { os: windows-2022, cxx: clang-cl,   c: clang-cl, arch: x64, gen: Ninja,                 cxx_max: 23 },
-          # { os: windows-2022, cxx: c++,        c: cc,       arch: x64, gen: Visual Studio 17 2022, cxx_max: 23 },
+          { os: ubuntu-24.04,        cxx: g++-12,           c: gcc-12,         arch: x64, gen: Ninja,                 cxx_max: 23 },
+          { os: ubuntu-24.04,        cxx: g++-13,           c: gcc-13,         arch: x64, gen: Ninja,                 cxx_max: 23 },
+          { os: ubuntu-24.04,        cxx: g++-14,           c: gcc-14,         arch: x64, gen: Ninja,                 cxx_max: 23 },
+          { os: ubuntu-24.04,        cxx: clang++-16,       c: clang-16,       arch: x64, gen: Ninja,                 cxx_max: 20 },
+          { os: ubuntu-24.04,        cxx: clang++-17,       c: clang-17,       arch: x64, gen: Ninja,                 cxx_max: 20 },
+          { os: ubuntu-24.04,        cxx: clang++-18,       c: clang-18,       arch: x64, gen: Ninja,                 cxx_max: 23 },
 
-          { os: windows-2025, cxx: cl,         c: cl,       arch: x86, gen: Visual Studio 17 2022, cxx_max: 23 },
-          { os: windows-2025, cxx: cl,         c: cl,       arch: x64, gen: Visual Studio 17 2022, cxx_max: 23 },
-          { os: windows-2025, cxx: clang-cl,   c: clang-cl, arch: x64, gen: Ninja,                 cxx_max: 23 },
-          # { os: windows-2025, cxx: c++,        c: cc,       arch: x64, gen: Visual Studio 17 2022, cxx_max: 23 },
+          { os: windows-2022,        cxx: cl,               c: cl,             arch: x86, gen: Visual Studio 17 2022, cxx_max: 23 },
+          { os: windows-2022,        cxx: cl,               c: cl,             arch: x64, gen: Visual Studio 17 2022, cxx_max: 23 },
+          { os: windows-2022,        cxx: clang-cl,         c: clang-cl,       arch: x64, gen: Ninja,                 cxx_max: 23 },
+          # { os: windows-2022,        cxx: c++,              c: cc,             arch: x64, gen: Visual Studio 17 2022, cxx_max: 23 },
+
+          { os: windows-2025-vs2026, cxx: cl,               c: cl,             arch: x86, gen: Visual Studio 18 2026, cxx_max: 23 },
+          { os: windows-2025-vs2026, cxx: cl,               c: cl,             arch: x64, gen: Visual Studio 18 2026, cxx_max: 23 },
+          { os: windows-2025-vs2026, cxx: clang-cl,         c: clang-cl,       arch: x64, gen: Ninja,                 cxx_max: 23 },
+          # { os: windows-2025-vs2026, cxx: c++,              c: cc,             arch: x64, gen: Visual Studio 18 2026, cxx_max: 23 },
 
           { os: macos-26,     cxx: /opt/homebrew/opt/llvm/bin/clang++, c: /opt/homebrew/opt/llvm/bin/clang, arch: x64, gen: Ninja, modules: true, cxx_max: 23, cxx_flags: '-I/opt/homebrew/opt/llvm/include/c++/v1 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk', linker_flags: '-L/opt/homebrew/opt/llvm/lib/c++' },
           { os: ubuntu-24.04, cxx: clang++-21, c: clang-21, arch: x64, gen: Ninja, modules: true, cxx_max: 23, cxx_flags: '-stdlib=libc++', linker_flags: '-stdlib=libc++ -lc++abi' },
@@ -53,7 +53,7 @@ jobs:
         ${{ matrix.env.cxx && format('-D CMAKE_CXX_COMPILER={0}', matrix.env.cxx) }} \
         ${{ matrix.env.cxx_flags && format('-D CMAKE_CXX_FLAGS''={0}''', matrix.env.cxx_flags) }} \
         ${{ matrix.env.linker_flags && format('-D CMAKE_EXE_LINKER_FLAGS=''{0}''', matrix.env.linker_flags) }} \
-      
+
     steps:
     - name: Checkout
       uses: actions/checkout@v5.0.0
@@ -135,7 +135,7 @@ jobs:
             if [ $CXX_STANDARD -lt 23 ] && ${{matrix.env.modules && true || false}}; then
               continue
             fi
-          
+
             echo "================================================================================="
             echo "Building C++$CXX_STANDARD in $BUILD_TYPE"
             echo "================================================================================="
@@ -150,5 +150,3 @@ jobs:
             ctest -j --output-on-failure --test-dir build -C $BUILD_TYPE
           done
         done
-
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,9 +42,9 @@ jobs:
           { os: windows-2025-vs2026, cxx: clang-cl,         c: clang-cl,       arch: x64, gen: Ninja,                 cxx_max: 23 },
           # { os: windows-2025-vs2026, cxx: c++,              c: cc,             arch: x64, gen: Visual Studio 18 2026, cxx_max: 23 },
 
-          { os: macos-26,     cxx: /opt/homebrew/opt/llvm/bin/clang++, c: /opt/homebrew/opt/llvm/bin/clang, arch: x64, gen: Ninja, modules: true, cxx_max: 23, cxx_flags: '-I/opt/homebrew/opt/llvm/include/c++/v1 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk', linker_flags: '-L/opt/homebrew/opt/llvm/lib/c++' },
+          { os: macos-26, cxx: /opt/homebrew/opt/llvm/bin/clang++, c: /opt/homebrew/opt/llvm/bin/clang, arch: x64, gen: Ninja, modules: true, cxx_max: 23, cxx_flags: '-I/opt/homebrew/opt/llvm/include/c++/v1 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk', linker_flags: '-L/opt/homebrew/opt/llvm/lib/c++' },
           { os: ubuntu-24.04, cxx: clang++-21, c: clang-21, arch: x64, gen: Ninja, modules: true, cxx_max: 23, cxx_flags: '-stdlib=libc++', linker_flags: '-stdlib=libc++ -lc++abi' },
-          { os: windows-2025, cxx: cl,         c: cl      , arch: x64, gen: Ninja, modules: true, cxx_max: 23, cxx_flags: '//EHsc' },
+          { os: windows-2025-vs2026, cxx: cl, c: cl, arch: x64, gen: Ninja, modules: true, cxx_max: 23, cxx_flags: '//EHsc' },
         ]
 
     env:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ For more details, check out the [workflow](.github/workflows/build.yml) that gov
 
 | [![CI Status](https://github.com/KhronosGroup/Vulkan-Hpp/actions/workflows/build.yml/badge.svg)](.github/workflows/build.yml) | GCC | Clang | MSVC |
 | :--- | :---: | :---: | :---: |
-| **Windows 2022** <br> **Windows 2025**            | - <br> - | 17 <br> 17 | VS 17 2022 <br> VS 17 2022 |
+| **Windows 2022** <br> **Windows 2025**            | - <br> - | 17 <br> 18 | VS 17 2022 <br> VS 18 2026 |
 | **Ubuntu 22.04** <br> **Ubuntu 24.04**            | 10, 11 <br> 12, 13, 14 | 13, 14, 15 <br> 16, 17, 18 | - <br> - |
 | **MacOS 14** <br> **MacOS 15** <br> **MacOS 16**  | - <br> - <br> - | 15 <br> 17 <br> 17 | - <br> - <br> - |
 


### PR DESCRIPTION
As per the notice from the `windows-2025` runner

```
NOTICE: windows-2025 requests are being redirected to windows-2025-vs2026 by May 12, 2026
```

I've replaced the `windows-2025` runner to perform this transition explicitly, so that we can fix potential issues before it is forced on us.